### PR TITLE
Release 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "must-be-valid",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Javascript library for type validation with Typescript support",
   "keywords": [
+    "data",
     "type",
     "validation",
     "javascript",

--- a/src/functions.test.ts
+++ b/src/functions.test.ts
@@ -1,5 +1,5 @@
 import { isFunction, mustBeFunction } from './functions'
-import { arrayOfUnknowns, arrayOfStrings, func1, func2, obj1, obj2 } from './mocks'
+import { arrayOfStrings, arrayOfUnknowns, func1, func2, obj1, obj2 } from './mocks'
 
 describe('Functions validation', () => {
   test('isFunction() validation', () => {

--- a/src/plainObjects.test.ts
+++ b/src/plainObjects.test.ts
@@ -1,4 +1,4 @@
-import { arrayOfUnknowns, arrayOfStrings, func1, func2, obj1, obj2 } from './mocks'
+import { arrayOfStrings, arrayOfUnknowns, func1, func2, obj1, obj2 } from './mocks'
 import { isPlainObject, mustBePlainObject } from './plainObjects'
 
 describe('Plain object validation', () => {

--- a/src/plainObjects.ts
+++ b/src/plainObjects.ts
@@ -1,8 +1,12 @@
-export function isPlainObject(value: unknown): value is { [key: string]: unknown } {
+export function isPlainObject<Key extends string | number | symbol, Value = unknown>(
+  value: Record<Key, Value> | Value
+): value is Record<Key, Value> {
   return value?.constructor === Object
 }
 
-export function mustBePlainObject(value: unknown): { [key: string]: unknown } {
-  if (isPlainObject(value)) return value
+export function mustBePlainObject<Key extends string | number | symbol, Value = unknown>(
+  value: Record<Key, Value> | Value
+): Record<Key, Value> {
+  if (isPlainObject(value)) return value as Record<Key, Value>
   throw new Error('Value must be an object')
 }

--- a/src/primitives.test.ts
+++ b/src/primitives.test.ts
@@ -1,4 +1,4 @@
-import { arrayOfUnknowns, arrayOfStrings, func1, func2, obj1, obj2 } from './mocks'
+import { arrayOfStrings, arrayOfUnknowns, func1, func2, obj1, obj2 } from './mocks'
 import { isNumber, isString, mustBeNumber, mustBeString } from './primitives'
 
 describe('Strings validation', () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -10,12 +10,13 @@ declare module 'must-be-valid' {
   export function mustBeArrayOf<T>(value: unknown, check: (arg: unknown) => arg is T): T[]
   export function isFunction(value: unknown): value is CallableFunction
   export function mustBeFunction(value: unknown): CallableFunction
-  export function isPlainObject(value: unknown): value is {
-    [key: string]: unknown
-  }
-  export function mustBePlainObject(value: unknown): {
-    [key: string]: unknown
-  }
+  export function isPlainObject<Key extends string | number | symbol, Value = unknown>(
+    value: Record<Key, Value> | Value
+  ): value is Record<Key, Value>
+  export function mustBePlainObject<
+    Key extends string | number | symbol,
+    Value = unknown
+  >(value: Record<Key, Value> | Value): Record<Key, Value>
   export function isString(value: unknown): value is string
   export function mustBeString(value: unknown): string
   export function isNumber(value: unknown): value is number


### PR DESCRIPTION
**Changelog**

- improved support for typescript inferencing of return types for methods: `isPlainObject` and `mustBePlainObject`