### PR TITLE
release(2.0.0): merge develop into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,55 @@ A Javascript library for type validation with Typescript support
 
 ## Install
 
-`npm install must-be-valid`
+```sh
+npm install must-be-valid
+```
 
 ## Use
 
 ```ts
 import {
-  isString,
-  mustBeArrayOf,
-  mustBeString,
+  mustBeArray,
   mustBeNumber,
   mustBePlainObject,
+  mustBeString,
 } from 'must-be-valid'
 
-function makeUser(userInfo: unknown): User {
-  const userInfoObject = mustBePlainObject(userInfo) // throws if not valid
+function makeUser(userDto: unknown) {
+  const userInfo = mustBePlainObject(userDto) // throws if not valid
 
   return {
-    userName: mustBeString(userInfoObject.userName), // throws if not valid
-    password: mustBeString(userInfoObject.password), // throws if not valid
-    age: mustBeNumber(userInfoObject.age), // throws if not valid
-    friendIds: mustBeArrayOf(userInfoObject.friendIds, isString), // throws  if not valid
+    userName: mustBeString(userInfo.userName), // throws if not valid
+    password: mustBeString(userInfo.password), // throws if not valid
+    age: mustBeNumber(userInfo.age), // throws if not valid
+    friendIds: mustBeArray(userInfo.friendIds).map((el) => mustBeString(el)), // throws if not valid
   }
+}
+```
+
+### Awesome type inferencing
+
+Thanks to extensive Typescript support by the library, including the use of generics, Typescript infers the following return type of `makeUser` function:
+
+```ts
+function makeUser(userDto: any): {
+  userName: string
+  password: string
+  age: number
+  friendIds: string[]
 }
 ```
 
 ## Contribute
 
+1. open an Issue on GitHub, describe the changes you want to introduce and check the feedback from community
 1. from branch `develop` create a feature branch with descriptive name
 2. make changes
 3. check for code style inconsistencies with `npm run lint`
 4. ensure all tests pass: `npm run test`
 5. submit a Pull request with description
+
+Thank you <3
 
 ## Contact author
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "must-be-valid",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A Javascript library for type validation with Typescript support",
   "keywords": [
     "data",

--- a/src/arrays.test.ts
+++ b/src/arrays.test.ts
@@ -1,22 +1,14 @@
+import { isArray, isNonEmptyArray, mustBeArray, mustBeNonEmptyArray } from './arrays'
 import {
-  isArray,
-  isArrayOf,
-  isNonEmptyArray,
-  mustBeArray,
-  mustBeArrayOf,
-  mustBeNonEmptyArray,
-} from './arrays'
-import {
-  arrayOfUnknowns,
   arrayOfArrays,
   arrayOfnumbers,
   arrayOfStrings,
+  arrayOfUnknowns,
   func1,
   func2,
   obj1,
   obj2,
 } from './mocks'
-import { isNumber, isString } from './primitives'
 
 describe('Array validation', () => {
   test('isArray() validation', () => {
@@ -75,26 +67,5 @@ describe('Array validation', () => {
     expect(mustBeNonEmptyArray(arrayOfStrings)).toBe(arrayOfStrings)
     expect(mustBeNonEmptyArray(arrayOfnumbers)).toBe(arrayOfnumbers)
     expect(mustBeNonEmptyArray(arrayOfArrays)).toBe(arrayOfArrays)
-  })
-
-  test('isArrayOf() validation', () => {
-    expect(isArrayOf('', isString)).toBe(false)
-    expect(isArrayOf([], isString)).toBe(false)
-    expect(isArrayOf(null, isNumber)).toBe(false)
-    expect(isArrayOf(0, isNumber)).toBe(false)
-    expect(isArrayOf([''], isString)).toBe(true)
-    expect(isArrayOf(arrayOfStrings, isString)).toBe(true)
-    expect(isArrayOf(arrayOfnumbers, isNumber)).toBe(true)
-    expect(isArrayOf(arrayOfArrays, isArray)).toBe(true)
-  })
-
-  test('mustBeArrayOf() validation', () => {
-    expect(() => mustBeArrayOf('', isString)).toThrow()
-    expect(() => mustBeArrayOf([], isString)).toThrow()
-    expect(() => mustBeArrayOf(null, isNumber)).toThrow()
-    expect(() => mustBeArrayOf(0, isNumber)).toThrow()
-    expect(mustBeArrayOf(arrayOfStrings, isString)).toBe(arrayOfStrings)
-    expect(mustBeArrayOf(arrayOfnumbers, isNumber)).toBe(arrayOfnumbers)
-    expect(mustBeArrayOf(arrayOfArrays, isArray)).toBe(arrayOfArrays)
   })
 })

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -17,15 +17,3 @@ export function mustBeNonEmptyArray<T>(value: T | T[]): T[] {
 
   throw new Error('The value must be a non empty array of arrays')
 }
-
-export function isArrayOf<T>(
-  value: unknown,
-  check: (arg: unknown) => arg is T
-): value is T[] {
-  return isNonEmptyArray(value) && value.every((element) => check(element))
-}
-
-export function mustBeArrayOf<T>(value: unknown, check: (arg: unknown) => arg is T): T[] {
-  if (isArrayOf(value, check)) return value
-  throw new Error('Elements of the array must be of specified type')
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,12 @@
-import {
-  isArray,
-  isArrayOf,
-  isNonEmptyArray,
-  mustBeArray,
-  mustBeArrayOf,
-  mustBeNonEmptyArray,
-} from './arrays'
+import { isArray, isNonEmptyArray, mustBeArray, mustBeNonEmptyArray } from './arrays'
 import { isFunction, mustBeFunction } from './functions'
 import { isPlainObject, mustBePlainObject } from './plainObjects'
 import { isNumber, isString, mustBeNumber, mustBeString } from './primitives'
 
 export {
   isArray,
-  isArrayOf,
   isNonEmptyArray,
   mustBeArray,
-  mustBeArrayOf,
   mustBeNonEmptyArray,
   isFunction,
   mustBeFunction,

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -1,14 +1,15 @@
-import { mustBeArrayOf } from './arrays'
+import { mustBeArray } from './arrays'
 import { mustBePlainObject } from './plainObjects'
-import { isString, mustBeNumber, mustBeString } from './primitives'
+import { mustBeNumber, mustBeString } from './primitives'
 
-function makeUser(userInfo: unknown) {
-  const userInfoObject = mustBePlainObject(userInfo) // throws an error if not valid
+function makeUser(userDto: unknown) {
+  const userInfo = mustBePlainObject(userDto) // throws if not valid
+
   return {
-    userName: mustBeString(userInfoObject.userName), // throws an error if not valid
-    password: mustBeString(userInfoObject.password), // throws an error if not valid
-    age: mustBeNumber(userInfoObject.age), // throws an error if not valid
-    friendIds: mustBeArrayOf(userInfoObject.friendIds, isString), // throws an error if not valid
+    userName: mustBeString(userInfo.userName), // throws if not valid
+    password: mustBeString(userInfo.password), // throws if not valid
+    age: mustBeNumber(userInfo.age), // throws if not valid
+    friendIds: mustBeArray(userInfo.friendIds).map((f) => mustBeString(f)), // throws if not valid
   }
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,11 +3,6 @@ declare module 'must-be-valid' {
   export function mustBeArray<T>(value: T | T[]): T[]
   export function isNonEmptyArray<T>(value: T | T[]): value is T[]
   export function mustBeNonEmptyArray<T>(value: T | T[]): T[]
-  export function isArrayOf<T>(
-    value: unknown,
-    check: (arg: unknown) => arg is T
-  ): value is T[]
-  export function mustBeArrayOf<T>(value: unknown, check: (arg: unknown) => arg is T): T[]
   export function isFunction(value: unknown): value is CallableFunction
   export function mustBeFunction(value: unknown): CallableFunction
   export function isPlainObject<Key extends string | number | symbol, Value = unknown>(


### PR DESCRIPTION
**Changelog**

- Remove methods `isArrayOf` and `mustBeArrayOf`
  - those were unnecessary since more intuitive notation is available: `mustBeArray(arr).map(el => mustBeString(el)`